### PR TITLE
docs: polling example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ mr.Handle(myFilter1, myHandler1)
 mr.Handle(myFilter2, myHandler2)
 
 mrPrivate := messages.NewRouter(mySecurityMiddleware)
-mr.Handle(myFilter, myPrivateHandler)
+mrPrivate.Handle(myFilter, myPrivateHandler)
 
 cr := callback.NewRouter()
 cr.Handle(myFilter3, myCallbackHandler)


### PR DESCRIPTION
It seems to me that instead of "mr.Handle()" there should be "mrPrivate.Handle()", isn't it?