### PR TITLE
fix: refactor the Download method to use client instead of http.Get

### DIFF
--- a/api.go
+++ b/api.go
@@ -41,7 +41,7 @@ func NewAPI(token, host string, client *http.Client) *API {
 }
 
 func (api *API) Download(filePath string) (*http.Response, error) {
-	return http.Get(api.host + "/file/bot" + api.token + "/" + filePath)
+	return api.client.Get(api.host + "/file/bot" + api.token + "/" + filePath)
 }
 
 func callJson[T any](a *API, method string, rawData any) (T, error) {


### PR DESCRIPTION
The title is quite self-explanatory. 